### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,17 +8,15 @@
 	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<java.version>21</java.version>
-		<spring.boot.version>3.2.0</spring.boot.version>
+		<spring.boot.version>4.0.5</spring.boot.version>
 		<jakarta-servlet.version>6.0.0</jakarta-servlet.version>
 		<guava.version>33.5.0-jre</guava.version>
 		<hsqldb.version>2.7.4</hsqldb.version>
-		<slf4j-api.version>2.0.17</slf4j-api.version>
-		<log4j-slf4j-impl.version>2.25.4</log4j-slf4j-impl.version>
 		<springdoc-openapi.version>1.8.0</springdoc-openapi.version>
 		<mapstruct.version>1.6.3</mapstruct.version>
 		<apache-httpclient.version>5.6</apache-httpclient.version>
 		<awaitility.version>4.2.0</awaitility.version>
-		<spring-cloud-contract.version>4.1.0</spring-cloud-contract.version>
+		<spring-cloud-contract.version>5.0.2</spring-cloud-contract.version>
 		<surefire-plugin.version>3.5.5</surefire-plugin.version>
 		<failsafe-plugin.version>3.5.5</failsafe-plugin.version>
 		<jib-plugin.version>3.5.1</jib-plugin.version>
@@ -170,26 +168,34 @@
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
 			<version>${apache-httpclient.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 			<version>${spring.boot.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-jpa-test</artifactId>
+			<version>${spring.boot.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-json</artifactId>
 			<version>${spring.boot.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>ch.qos.logback</groupId>
-					<artifactId>logback-classic</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-to-slf4j</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -200,7 +206,16 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-tomcat</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
+			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -213,19 +228,15 @@
 			<version>${jakarta-servlet.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>${log4j-slf4j-impl.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j-api.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 			<version>${spring.boot.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -246,6 +257,16 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-contract-verifier</artifactId>
 			<version>${spring-cloud-contract.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-commons</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,23 +7,23 @@
 	<artifactId>fin-planner</artifactId>
 	<version>1.0-SNAPSHOT</version>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<spring.boot.version>3.2.0</spring.boot.version>
 		<jakarta-servlet.version>6.0.0</jakarta-servlet.version>
-		<guava.version>32.1.3-jre</guava.version>
-		<hsqldb.version>2.7.2</hsqldb.version>
-		<slf4j-api.version>2.0.9</slf4j-api.version>
-		<log4j-slf4j-impl.version>2.22.0</log4j-slf4j-impl.version>
-		<springdoc-openapi.version>1.7.0</springdoc-openapi.version>
-		<mapstruct.version>1.5.5.Final</mapstruct.version>
-		<apache-httpclient.version>5.3</apache-httpclient.version>
+		<guava.version>33.5.0-jre</guava.version>
+		<hsqldb.version>2.7.4</hsqldb.version>
+		<slf4j-api.version>2.0.17</slf4j-api.version>
+		<log4j-slf4j-impl.version>2.25.4</log4j-slf4j-impl.version>
+		<springdoc-openapi.version>1.8.0</springdoc-openapi.version>
+		<mapstruct.version>1.6.3</mapstruct.version>
+		<apache-httpclient.version>5.6</apache-httpclient.version>
 		<awaitility.version>4.2.0</awaitility.version>
 		<spring-cloud-contract.version>4.1.0</spring-cloud-contract.version>
-		<surefire-plugin.version>3.2.3</surefire-plugin.version>
-		<failsafe-plugin.version>3.2.3</failsafe-plugin.version>
-		<jib-plugin.version>3.4.0</jib-plugin.version>
-		<jacoco-plugin.version>0.8.11</jacoco-plugin.version>
-		<maven-compiler-plugin.version>3.12.0</maven-compiler-plugin.version>
+		<surefire-plugin.version>3.5.5</surefire-plugin.version>
+		<failsafe-plugin.version>3.5.5</failsafe-plugin.version>
+		<jib-plugin.version>3.5.1</jib-plugin.version>
+		<jacoco-plugin.version>0.8.14</jacoco-plugin.version>
+		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 		<itCoverageAgent></itCoverageAgent>
 	</properties>
 	<build>

--- a/src/main/java/hu/zsomboro/ptracker/PortfolioTrackerApplication.java
+++ b/src/main/java/hu/zsomboro/ptracker/PortfolioTrackerApplication.java
@@ -2,7 +2,7 @@ package hu.zsomboro.ptracker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = { "hu.zsomboro.ptracker.*" })

--- a/src/main/java/hu/zsomboro/ptracker/client/YahooPriceClient.java
+++ b/src/main/java/hu/zsomboro/ptracker/client/YahooPriceClient.java
@@ -47,7 +47,7 @@ public class YahooPriceClient implements PriceClient, FxRateClient {
   }
 
   private Result callAPIWithIdentifierInternal(String identifier) {
-    String urlTemplate = UriComponentsBuilder.fromHttpUrl(YAHOO_QUOTE_URL).queryParam(SYMBOL, "{" + SYMBOL + "}")
+    String urlTemplate = UriComponentsBuilder.fromUriString(YAHOO_QUOTE_URL).queryParam(SYMBOL, "{" + SYMBOL + "}")
         .queryParam(FIELDS, "{" + FIELDS + "}").encode().toUriString();
 
     ResponseEntity<YahooFinanceAPIResponse> response = this.restTemplate.exchange(urlTemplate, HttpMethod.GET, null,

--- a/src/main/java/hu/zsomboro/ptracker/common/PriceMapper.java
+++ b/src/main/java/hu/zsomboro/ptracker/common/PriceMapper.java
@@ -1,8 +1,6 @@
 package hu.zsomboro.ptracker.common;
 
-import hu.zsomboro.ptracker.core.Cash;
 import hu.zsomboro.ptracker.core.Price;
-import hu.zsomboro.ptracker.persistence.entity.CashDO;
 import hu.zsomboro.ptracker.persistence.entity.PriceDO;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;

--- a/src/main/java/hu/zsomboro/ptracker/common/RestConfiguration.java
+++ b/src/main/java/hu/zsomboro/ptracker/common/RestConfiguration.java
@@ -21,10 +21,10 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @Configuration
 public class RestConfiguration {
@@ -43,11 +43,10 @@ public class RestConfiguration {
   }
 
   @Bean
-  public RestTemplate restTemplate(HttpClient httpClient, ObjectMapper mapper) {
+  public RestTemplate restTemplate(HttpClient httpClient, JsonMapper mapper) {
     HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
     requestFactory.setHttpClient(httpClient);
-    MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
-    converter.setObjectMapper(mapper);
+    JacksonJsonHttpMessageConverter converter = new JacksonJsonHttpMessageConverter(mapper);
     RestTemplate restTemplate = new RestTemplate(requestFactory);
     restTemplate.setMessageConverters(List.of(converter));
     return restTemplate;

--- a/src/main/java/hu/zsomboro/ptracker/service/FxRateService.java
+++ b/src/main/java/hu/zsomboro/ptracker/service/FxRateService.java
@@ -5,10 +5,10 @@ import java.util.Map;
 
 public interface FxRateService {
 
-  public double getHufFxRate(LocalDate asOfDate, String forIsoCurrency);
+  double getHufFxRate(LocalDate asOfDate, String forIsoCurrency);
 
-  public void saveHufFxRate(LocalDate asOfDate, String forIsoCurrency, double value);
+  void saveHufFxRate(LocalDate asOfDate, String forIsoCurrency, double value);
 
-  public Map<String, Double> getAllFxRatesForDay(LocalDate asOfDate);
+  Map<String, Double> getAllFxRatesForDay(LocalDate asOfDate);
 
 }

--- a/src/main/java/hu/zsomboro/ptracker/service/LoadedPriceService.java
+++ b/src/main/java/hu/zsomboro/ptracker/service/LoadedPriceService.java
@@ -8,10 +8,10 @@ import hu.zsomboro.ptracker.core.security.HasPrice;
 
 public interface LoadedPriceService {
 
-  public Price getPrice(LocalDate asOfDate, HasPrice pricedInstrument);
+  Price getPrice(LocalDate asOfDate, HasPrice pricedInstrument);
 
-  public Map<LocalDate, Price> getPriceHistory(HasPrice pricedInstrument);
+  Map<LocalDate, Price> getPriceHistory(HasPrice pricedInstrument);
 
-  public Map<String, Price> getAllPricesForDay(LocalDate asOfDate);
+  Map<String, Price> getAllPricesForDay(LocalDate asOfDate);
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,3 @@ management.endpoint.health.show-details=when-authorized
 # https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.spring-mvc.customize-jackson-objectmapper
 spring.jackson.deserialization.FAIL_ON_IGNORED_PROPERTIES=false
 spring.jackson.default-property-inclusion=non_null
-spring.jackson.serialization.write-dates-as-timestamps=false

--- a/src/test/java/hu/zsomboro/ptracker/client/TestYahooPriceClient.java
+++ b/src/test/java/hu/zsomboro/ptracker/client/TestYahooPriceClient.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;

--- a/src/test/java/hu/zsomboro/ptracker/integration/contract/PortfolioControllerBase.java
+++ b/src/test/java/hu/zsomboro/ptracker/integration/contract/PortfolioControllerBase.java
@@ -1,7 +1,7 @@
 package hu.zsomboro.ptracker.integration.contract;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;

--- a/src/test/java/hu/zsomboro/ptracker/persistence/TestFxRatePersistence.java
+++ b/src/test/java/hu/zsomboro/ptracker/persistence/TestFxRatePersistence.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import hu.zsomboro.ptracker.persistence.entity.FxRateId;

--- a/src/test/java/hu/zsomboro/ptracker/persistence/TestPortfolioPersistence.java
+++ b/src/test/java/hu/zsomboro/ptracker/persistence/TestPortfolioPersistence.java
@@ -15,8 +15,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.test.context.ContextConfiguration;
 
 import hu.zsomboro.ptracker.core.security.InstrumentType;

--- a/src/test/java/hu/zsomboro/ptracker/persistence/TestPricePersistence.java
+++ b/src/test/java/hu/zsomboro/ptracker/persistence/TestPricePersistence.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import hu.zsomboro.ptracker.persistence.entity.PriceDO;

--- a/src/test/java/hu/zsomboro/ptracker/persistence/TestPricePersistence.java
+++ b/src/test/java/hu/zsomboro/ptracker/persistence/TestPricePersistence.java
@@ -112,7 +112,7 @@ public class TestPricePersistence {
     price3.setIdentifier("dummy");
     price3.setPrice(12.55d);
 
-    priceRepo.saveAll(List.of(price1, price2));
+    priceRepo.saveAll(List.of(price1, price2, price3));
 
     List<PriceDO> foundPrices = priceRepo.findByIdentifier(identifier);
 

--- a/src/test/java/hu/zsomboro/ptracker/schedule/ClosingPriceLoadingSchedulerTest.java
+++ b/src/test/java/hu/zsomboro/ptracker/schedule/ClosingPriceLoadingSchedulerTest.java
@@ -8,25 +8,27 @@ import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import hu.zsomboro.ptracker.service.PriceLoaderService;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration
+@ContextConfiguration(classes = ClosingPriceLoadingSchedulerTest.TestConfig.class)
 @TestPropertySource(properties = "price.load.cron=*/2 * * ? * *")
 @EnableScheduling
-public class ClosingPriceLoadingSchedulerTest {
+class ClosingPriceLoadingSchedulerTest {
 
-  @MockBean
-  private PriceLoaderService priceLoaderSerivce;
+  @MockitoBean
+  private PriceLoaderService priceLoaderService;
 
-  @SpyBean
+  @MockitoSpyBean
   private ClosingPriceLoadingScheduler scheduler;
 
   @Test
@@ -35,4 +37,11 @@ public class ClosingPriceLoadingSchedulerTest {
         .untilAsserted(() -> verify(scheduler, atLeast(1)).loadPricesAndFxRates());
   }
 
+  @Configuration
+  static class TestConfig {
+    @Bean
+    ClosingPriceLoadingScheduler closingPriceLoadingScheduler(PriceLoaderService priceLoaderService) {
+      return new ClosingPriceLoadingScheduler(priceLoaderService);
+    }
+  }
 }

--- a/src/test/java/hu/zsomboro/ptracker/service/FxRateServiceImplTest.java
+++ b/src/test/java/hu/zsomboro/ptracker/service/FxRateServiceImplTest.java
@@ -3,11 +3,8 @@ package hu.zsomboro.ptracker.service;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -15,7 +12,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@ContextConfiguration
+@Import(FxRateServiceImpl.class)
 public class FxRateServiceImplTest {
 
   @Autowired
@@ -40,14 +37,6 @@ public class FxRateServiceImplTest {
    Map<String, Double> fxRatesForDay = fxRateService.getAllFxRatesForDay(LocalDate.now());
 
    assertThat(fxRatesForDay).hasSize(2).containsKeys("EUR", "USD").containsValues(300.d, 290.d);
-  }
-
-  @Configuration
-  @EnableAutoConfiguration
-  @ComponentScan(basePackages = { "hu.zsomboro.ptracker.common", "hu.zsomboro.ptracker.service",
-      "hu.zsomboro.ptracker.persistence" })
-  public static class SpringServiceTestConfig {
-
   }
 
 }

--- a/src/test/java/hu/zsomboro/ptracker/service/LoadedPriceServiceImplTest.java
+++ b/src/test/java/hu/zsomboro/ptracker/service/LoadedPriceServiceImplTest.java
@@ -1,18 +1,14 @@
 package hu.zsomboro.ptracker.service;
 
 import hu.zsomboro.ptracker.core.Price;
-import hu.zsomboro.ptracker.core.security.HasPrice;
 import hu.zsomboro.ptracker.persistence.PriceDORepository;
 import hu.zsomboro.ptracker.persistence.entity.PriceDO;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -20,7 +16,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@ContextConfiguration
+@Import(LoadedPriceServiceImpl.class)
 public class LoadedPriceServiceImplTest {
 
   @Autowired
@@ -81,15 +77,6 @@ public class LoadedPriceServiceImplTest {
     price1.setAsOfDate(asOf);
     price1.setCurrency(currency);
     priceDORepository.save(price1);
-  }
-
-
-  @Configuration
-  @EnableAutoConfiguration
-  @ComponentScan(basePackages = { "hu.zsomboro.ptracker.common", "hu.zsomboro.ptracker.service",
-      "hu.zsomboro.ptracker.persistence" })
-  public static class SpringServiceTestConfig {
-
   }
 
 }

--- a/src/test/java/hu/zsomboro/ptracker/service/PortfolioServiceImplTest.java
+++ b/src/test/java/hu/zsomboro/ptracker/service/PortfolioServiceImplTest.java
@@ -10,19 +10,18 @@ import hu.zsomboro.ptracker.core.security.HasPrice;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hu.zsomboro.ptracker.client.FxRateClient;
 import hu.zsomboro.ptracker.client.PriceClient;
 import hu.zsomboro.ptracker.core.Portfolio;
 import hu.zsomboro.ptracker.core.security.EquitySecurity;
 import hu.zsomboro.ptracker.core.security.FixedIncomeSecurity;
+import tools.jackson.databind.json.JsonMapper;
 
 @DataJpaTest
 @ContextConfiguration
@@ -132,8 +131,8 @@ public class PortfolioServiceImplTest {
     }
 
     @Bean
-    public ObjectMapper objectMapper() {
-      return new ObjectMapper();
+    public JsonMapper jsonMapper() {
+      return new JsonMapper();
     }
 
   }

--- a/src/test/java/hu/zsomboro/ptracker/service/PriceLoaderServiceTest.java
+++ b/src/test/java/hu/zsomboro/ptracker/service/PriceLoaderServiceTest.java
@@ -14,14 +14,14 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import hu.zsomboro.ptracker.client.FxRateClient;
@@ -37,20 +37,19 @@ import hu.zsomboro.ptracker.persistence.entity.PriceDO;
 @ContextConfiguration
 public class PriceLoaderServiceTest {
 
-  @MockBean
+  @MockitoBean
   private PriceDORepository priceRepository;
-  @MockBean
+  @MockitoBean
   private HufFxRateDORepository fxRateRepository;
-  @MockBean
+  @MockitoBean
   private PortfolioService portfolioService;
-  @MockBean
+  @MockitoBean
   private PriceClient priceClient;
-  @MockBean
+  @MockitoBean
   private FxRateClient fxRateClient;
   @Autowired
   private PriceLoaderService priceLoaderService;
-  @Captor
-  private ArgumentCaptor<Iterable<?>> collectionCaptor;
+  private ArgumentCaptor<Iterable<?>> collectionCaptor = ArgumentCaptor.forClass((Class) Iterable.class);
 
   @SuppressWarnings("unchecked")
   @Test


### PR DESCRIPTION
## Summary
- Upgraded core platform dependencies:
  - `java.version`: `17` -> `21`
  - `spring.boot.version`: `3.2.0` -> `4.0.5`
  - `spring-cloud-contract.version`: `4.1.0` -> `5.0.2`
- Upgraded supporting libraries:
  - `guava`: `32.1.3-jre` -> `33.5.0-jre`
  - `hsqldb`: `2.7.2` -> `2.7.4`
  - `springdoc-openapi`: `1.7.0` -> `1.8.0`
  - `mapstruct`: `1.5.5.Final` -> `1.6.3`
  - `httpclient5`: `5.3` -> `5.6`
- Upgraded build/test plugins:
  - `maven-surefire-plugin`: `3.2.3` -> `3.5.5`
  - `maven-failsafe-plugin`: `3.2.3` -> `3.5.5`
  - `jacoco-maven-plugin`: `0.8.11` -> `0.8.14`
  - `maven-compiler-plugin`: `3.12.0` -> `3.15.0`
  - `jib-maven-plugin`: `3.4.0` -> `3.5.1`

## Dependency wiring changes
- Switched logging to Spring Boot-managed Log4j2 autoconfiguration:
  - added `spring-boot-starter-log4j2`
  - removed explicit `slf4j-api` and `log4j-slf4j2-impl`
  - excluded `spring-boot-starter-logging` from selected Boot starters to avoid Logback conflicts
  - excluded transitive `slf4j-api` from `httpclient5` to avoid SLF4J 1.7 vs 2.x classpath conflicts
- Added `spring-boot-data-jpa-test` for Boot 4-compatible JPA test support.
- Added exclusions under `spring-cloud-starter-contract-verifier` to avoid JUnit classpath conflicts with Boot 4:
  - `org.junit.jupiter:junit-jupiter-api`
  - `org.junit.platform:junit-platform-commons`